### PR TITLE
Pl website tool

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/Repair_Demand_Letter_to_include.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/Repair_Demand_Letter_to_include.yml
@@ -541,10 +541,10 @@ subject: |
   What if the problems happened at different times?
 content: |
   % if person_answering == "tenant":
-  Use this tool to come up with your best estimate of the
+  Use UpToCode to come up with your best estimate of the
   amount to ask for. It does not need to be exact.
   % else:
-  Use this tool to come up with the tenant's best estimate of the amount to as for. It does not need to be exact.
+  Use UpToCode to come up with the tenant's best estimate of the amount to as for. It does not need to be exact.
   % endif
 ---
 depends on:

--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -240,13 +240,13 @@ subject: |
 content: |
   % if person_answering == "tenant":
   Your landlord's contact information will be written
-  on the documents that this website creates.
+  on the documents that UpToCode creates.
 
   The court may use the number or email to pick a time
   for you and your landlord to come into court.
   % else:
   The landlord's contact information will be written
-  on the documents that this website creates.
+  on the documents that UpToCode creates.
 
   The court may use the number or email to pick a time
   for the tenant and their landlord to come into court.
@@ -673,9 +673,9 @@ content: |
   you need to be able to tell your landlord and the court where the problem
   is.
   
-  You can use this website to record problems and upload pictures.
+  You can use UpToCode to record problems and upload pictures.
   
-  You could also:
+  You can also:
   
   * Use your phone or a camera to take pictures of the problems.
   * Use a thermometer or a photo of your thermostat and write down the
@@ -688,18 +688,16 @@ template: how_to_notify_landlord_template
 subject: |
   Notify your landlord
 content: |
-  Your landlord is only responsible to fix problems that they know about.
-  Make sure your landlord knows about problems in your house by telling them,
-  even if you think that they should already know.
+  Your landlord is responsible for fixing only the problems they know about.
+  Make sure you tell your landlord about problems in your home, even if you think they should already know.
   
-  Use a way to tell your landlord that you can track and prove.
+  Tell your landlord about the problems in a way that you can prove you told them.
   
-  * Write your landlord a text message.
-  * Write a letter on paper, and keep a copy for yourself. Make sure the date
-    is on the letter.
-  * Write an email.
+  * Text your landlord. Keep the text or a screenshot of the text on your phone.
+  * Write a letter. Make sure to put the date on the letter. Keep a copy for yourself. 
+  * Email your landlord.
   
-  You can use this website to tell your landlord about the problems in your
+  You can use UpToCode to tell your landlord about the problems in your
   home.
 ---
 template: get_inspection_template
@@ -722,8 +720,8 @@ content: |
   
   In other cities and towns, call the Board of Health.
   
-  Before calling the inspector, use this website to create and print a list of 
-  the problems that you have identified. This will help make sure that the
+  Before you call the inspector, use UpToCode to create and print a list of 
+  the problems that you have identified. This will help make sure the
   inspector does not miss any problems.
 
   [Learn more](https://www.masslegalhelp.org/housing/lt1-chapter-8-getting-inspection).
@@ -1138,10 +1136,10 @@ content: |
 
   <h3 class="h5">You need to know</h3>
 
-  * **This website does not provide legal advice**. If you need legal advice, you can use the [Massachusetts Legal Resource Finder](https://masslrf.org) to find a lawyer.
-  * The information and documents on this website have no warranty. We provide the information “as-is.” By using the site, you agree not to hold GBLS or the information providers on this site liable.
-  * We work hard to keep the information on the site up to date. Lawyers drafted and reviewed the documents this site uses. But laws and local rules change over time. These changes can make a document unenforceable when you use it.
-  * We do our best to keep the site working! To do that, we allow you to submit feedback so we can track problems on the site. But we cannot provide individual technical support.
+  * **UpToCode does not provide legal advice**. If you need legal advice, you can use the [Massachusetts Legal Resource Finder](https://masslrf.org) to find a lawyer.
+  * The information and documents on UpToCode have no warranty. We provide the information “as-is.” By using UpToCode, you agree not to hold GBLS or the information providers on UpToCode liable.
+  * We work hard to keep the information on UpToCode up to date. Lawyers drafted and reviewed the documents UpToCode uses. But laws and local rules change over time. These changes can make a document unenforceable when you use it.
+  * We do our best to keep UpToCode working! To do that, we allow you to submit feedback so we can track problems on UpToCode. But we cannot provide individual technical support.
 
   <h3 class="h5">To use this site</h3>
 
@@ -1155,8 +1153,8 @@ content: |
   * We collect the information that you type to help you complete your forms. We delete all information 180 days after you last update it. You can also delete information immediately.
   * We log information including IP addresses and web browsers from all visitors. We use this information to keep our site secure. We keep logs for up to 180 days.
   * We use Google Maps to help fill in addresses automatically. This feature sends your IP address to Google Maps to get your approximate location.
-  * We use Google Analytics to learn how people use our website. This helps us understand which pages are hardest to use. Google may use this information to show you better advertisements.
-  * We use email and text message delivery services that may keep their own records of any messages you send. If you choose to log in with your phone number, this may include a record of the times you log in to the site.
+  * We use Google Analytics to learn how people use UpToCode. The analytics help us understand which pages are hardest to use. Google may use this information to show you better advertisements.
+  * We use email and text message delivery services that may keep their own records of any messages you send. If you choose to log in with your phone number, this may include a record of the times you log in to UpToCode.
 
   <h3 class="h5">We keep your information safe</h3>
 

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -452,7 +452,7 @@ question: |
   Find ways to get the problems in your home fixed
 subquestion: |
   <div class="alert alert-secondary h-100 mh-100" role="alert">
-    <h2 class="h4 alert-heading"><i class="fa-solid fa-signs-post"></i> How this tool works</h2>
+    <h2 class="h4 alert-heading"><i class="fa-solid fa-signs-post"></i> How UpToCode works</h2>
     <p class="h-100 overflow-visible mb-0">
 
   On the next few screens you can:
@@ -710,23 +710,18 @@ template: when_does_8a_apply
 subject: |
   When can a problem stop my eviction?
 content: |
-  If you are being evicted only because:
+  If your landlord owes you at least $1 because of a repair they did not make or they broke another landlord-tenant law.[239 &sect; 8A](https://www.masslegalhelp.org/housing/lt1-chapter-12-legal-defenses-counterclaims-article) gives you the right to "buy back" your home.
+  
+  239 &sect; 8A may protect you if you are being evicted only because:
 
-  * you owe rent, or
-  * your landlord only wants you to move out and is not saying it is your fault
+  * You owe rent. Or
+  * Your landlord wants you to move out, but not because of anything you did wrong.
 
-  you may be protected from eviction by [239 &sect; 8A](https://www.masslegalhelp.org/housing/lt1-chapter-12-legal-defenses-counterclaims-article).
+  You do not have this right if your landlord is evicting you because of a "fault" reason, like breaking any other rule in your lease. 
 
-  239 &sect; 8A gives you the right to "buy back" your home if your landlord owes you
-  at least $1 because of a repair that they did not make or they violated another 
-  landlord-tenant law.
-
-  You cannot use this right if your landlord is evicting you because of a "fault" reason,
-  such as breaking a rule in your lease other than being behind in the rent.
-
-  You can use the "buy back" right to stop an eviction if you raise it in your eviction
-  case. You need to file an eviction answer using [MADE](https://gbls.org/MADE) to claim
-  it instead of using this website.
+  You can use your "buy back" right to stop an eviction if you raise it in your eviction case. 
+  
+  Use [MADE](https://gbls.org/MADE) to claim this right in your eviction answer. UpToCode does not help with writing an answer.
 ---
 id: warn against suing
 question: |
@@ -739,7 +734,7 @@ subquestion: |
 
   - If the problem is in a public part of your building, or
   - The problem existed before you moved in, or
-  - Your landlord came to your apartment for another reason and had a chance to see the problem
+  - Your landlord came to your apartment for another reason and had a chance to see the problem.
 fields:
   - What do you want to do?: confirm_suing_choice
     datatype: radio
@@ -752,13 +747,13 @@ question: |
   Calling an inspector
 subquestion: |
   It is usually a good idea to call a housing inspector if you sue your
-  landlord. The court will pay attention to the problems that the inspector
-  found. The report that the inspector writes may be evidence in your case.
+  landlord. The court will pay attention to the problems the inspector
+  finds. The report the inspector writes may be evidence in your case.
 
-  You do not have to call an inspector before you use this website but you may want to
-  get the inspection before you deliver the papers to court.
+  You do not have to call an inspector before you use UpToCode. But you may want to
+  get an inspection report before you file your papers at court.
 
-  If it is an emergency you do not have to wait.
+  If it is an emergency you do not have to wait for an inspection report.
 fields:
   - Do you want to include a letter to your city or town inspector?: add_inspection_letter
     datatype: yesnoradio
@@ -842,7 +837,7 @@ id: track conditions intro
 question: |
   List your housing problems
 subquestion: |
-  This website will help you make your list.
+  UpToCode will help you make your list.
 continue button field: track_conditions_intro  
 ---
 id: learn more
@@ -1679,9 +1674,9 @@ subquestion: |
   % endif
   1. Deliver the court forms to the ${ trial_court } at ${ trial_court.address.on_one_line() }. You can call the court for instructions at ${ tel(trial_court.phone_number) }.
   % if person_answering == "tenant":
-  1. You can come back to this website later to take additional steps.
+  1. You can come back to UpToCode later to take additional steps.
   % else:
-  1. The tenant can come back to this website later to take additional steps.
+  1. The tenant can come back to UpToCode later to take additional steps.
   % endif
   % if showifdef("interview_order_request_housing_inspection") and person_answering == "tenant":
 
@@ -1941,11 +1936,11 @@ fields:
   - note: |
       % if person_answering == "tenant":
       **Okay**. You need your landlord's address for many of the forms on
-      this website. You can still finish this form but you will need to add
+      UpToCode. You can finish this form but you will need to add
       your landlord's address before you deliver the form.
       % else:
       **Okay**. The tenant needs their landlord's address for many of the forms on
-      this website. You can still finish this form but the tenant will need to add
+      UpToCode. You can finish this form but the tenant will need to add
       their landlord's address before the tenant delivers the form.
       % endif
     show if: ll_address_unknown       
@@ -2161,18 +2156,18 @@ back button label: |
 template: about_this_interview_version_info
 content: |
   UpToCode is a free website that gives tenants the power to solve
-  landlord problems. It's funded by the national Legal Services Corporation and
+  landlord problems. It is funded by the national Legal Services Corporation and
   Massachusetts nonprofits.
   
   UpToCode does not share any personal identifying information with the government or any other entity. 
 
-  UpToCode includes a translated and easy to read English version of the Massachusetts
-  Sanitary Code, the law that lists the requirements that Massachusetts landlords
-  must follow. It helps tenants:
+  UpToCode includes a translated and easy-to-read English version of the Massachusetts
+  Sanitary Code, the law that lists the requirements Massachusetts landlords
+  must follow. UpToCode helps tenants:
   
-  1. discover their rights under the law,
-  1. report problems to their landlord, a city housing inspector, or the court,
-  1. get a court order to enforce repairs or to get compensation for illegal landlord
+  1. Discover their rights under the law.
+  1. Report problems to their landlord, a city housing inspector, or the court,
+  1. Ask a court for an order to enforce repairs or get compensation for illegal landlord
   actions.
 
   UpToCode was originally authored by Quinten Steenhuis in 2021 in
@@ -2187,7 +2182,7 @@ content: |
   
   Community organizations [La Colaborativa](https://la-colaborativa.org) and
   [Lynn United for Change](https://lynnunited.org) played a special role in
-  co-design of this website.
+  co-design of UpToCode.
 
   &copy; 2022 Northeast Legal Aid, Quinten Steenhuis and open source
   contributors under an [MIT license](https://opensource.org/licenses/MIT).  

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -229,7 +229,7 @@ id: landing-page
 question: |
   You deserve a safe and decent home
 subquestion: |
-  Need help with repairs or stopping landlord harassment? Select a task to get started.
+  Need help to get repairs or stop your landlord from harassing you? Pick a task.
   
   % if device() and hasattr(device(), "is_mobile") and device().is_mobile:
 
@@ -239,9 +239,9 @@ subquestion: |
     <div class="row g-0">
       <div class="col-md-8">
         <div class="card-body bg-info">
-          <h5 class="card-title"><i class="fa-solid fa-magnifying-glass"></i> Explore problems and solutions</h5>
-          <p class="card-text">Explore problems by room and category and get your landlord to fix them.</p>
-          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start exploring</a>
+          <h5 class="card-title"><i class="fa-solid fa-magnifying-glass"></i> Describe  problems and find solutions</h5>
+          <p class="card-text">List problems by room and category and get your landlord to fix them.</p>
+          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start your list</a>
         </div>
       </div>
     </div>
@@ -304,9 +304,9 @@ subquestion: |
       </div>
       <div class="col-md-8">
         <div class="card-body">
-          <h5 class="card-title">Explore problems and solutions</h5>
-          <p class="card-text">Explore problems by room and category and get your landlord to fix them.</p>
-          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start exploring</a>
+          <h5 class="card-title">Describe  problems and find solutions</h5>
+          <p class="card-text">List problems by room and category and get your landlord to fix them.</p>
+          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start your list</a>
         </div>
       </div>
     </div>
@@ -449,7 +449,7 @@ fields:
 ---
 continue button field: intro_and_terms_of_use
 question: |
-  Explore solutions to the problems in your home
+  Find ways to get the problems in your home fixed
 subquestion: |
   <div class="alert alert-secondary h-100 mh-100" role="alert">
     <h2 class="h4 alert-heading"><i class="fa-solid fa-signs-post"></i> How this tool works</h2>
@@ -459,14 +459,14 @@ subquestion: |
 
   <ol>
   <li>
-    Track the problems in each room of your home. You can add dates and photos, too.
+    List the problems in each room of your home. You can add dates and photos, too.
   </li>
   <li>
   Answer questions to help you:
   <ul>
-  <li>write your landlord a letter,</li>
-  <li>ask the city for an inspection, or</li>
-  <li>ask a judge to order your landlord to fix the problem.</li>
+  <li>Write a letter to your landlord.</li>
+  <li>Ask the city for an inspection. Or</li>
+  <li>Ask a judge to order your landlord to fix the problem.</li>
   </ul>
   </li>
   <li>
@@ -840,9 +840,9 @@ continue button label: Get started
 ---
 id: track conditions intro
 question: |
-  Track your housing problems
+  List your housing problems
 subquestion: |
-  This website will help you track.
+  This website will help you make your list.
 continue button field: track_conditions_intro  
 ---
 id: learn more
@@ -1008,10 +1008,10 @@ subquestion: |
   ${ collapse_template(how_many_problems_are_there_template)}
 
 fields:
-  - Keep exploring problems?: wants_detailed_conditions
+  - Add more problems?: wants_detailed_conditions
     datatype: radio
     choices:
-      - ${"Yes, explore problems I may have in each room" if person_answering == "tenant" else "Yes, explore problems the tenant may have in each room"}: True
+      - ${"Yes, see more problems I may have in each room" if person_answering == "tenant" else "Yes, see more problems the tenant may have in each room"}: True
       - No, go straight to a solution: False
 ---
 template: how_many_problems_are_there_template
@@ -1023,24 +1023,23 @@ subject: |
   % endif
 content: |
   % if person_answering == "tenant":
-  If you explore by room and category, you can pick from a list of about
-  150 problems. Some may be problems you did not know your
+  You can pick from a list of about
+  150 problems organized by room and category. Some problems you may not know your
   landlord needs to fix.
   % else:
-  If the tenant explores by room and category, the tenant can pick from a 
-  list of about 150 problems. Some may be problems that the tenant did 
+  The tenant can pick from a 
+  list of about 150 problems organized by room and category. Some problems the tenant may
   not know their landlord needs to fix.
   % endif
 
-  The list of problems comes from the State Sanitary Code. We have
-  translated the Sanitary Code into easier to understand sentences
-  with short explanations.
+  The list of problems comes from the State Sanitary Code. We put the Code into sentences
+  with short explanations so it is easier to understand.
 ---  
 # WARNING: This page id needs to stay the same or the selectors for
 # the button styles in styles.css will need to be updated to match
 id: room chooser
 question: |
-  Explore problems by room and category
+  Look at problems by room and category
 subquestion: |
   % if len(bad_conditions) > 1 and person_answering == "tenant":
   You have already listed problems in these rooms and categories:
@@ -1065,7 +1064,7 @@ buttons:
 back button label: |
   Back
 under: |
-  You can keep exploring problems by room and category, or skip ahead
+  Keep looking at problems by room and category, or skip ahead
   to start working on a solution.
   
   % if len(bad_conditions.elements):
@@ -1125,10 +1124,10 @@ id: Claims
 question: |
   Emergency problems
 subquestion: |
-  Your landlord should start fixing any problem listed below within 24 hours
-  of learning about the problem.
+  Your landlord should start to fix these problems within 24 hours from the time they 
+  learn about the problem.
   
-  If you do not see your problem listed below, try a different room or category.
+  If you do not see the problem you are looking for, try a different room or category.
 
   ${ collapse_template(emergency_sanitary_code_template) }
 fields:
@@ -1145,7 +1144,7 @@ template: emergency_sanitary_code_template
 subject: |
   Related Sanitary Code
 content: |
-  The problems listed below are cited in the following sections of the
+  These problems are listed in the following sections of the
   [Sanitary Code](https://www.mass.gov/doc/105-cmr-410-state-sanitary-code-chapter-ii-minimum-standards-of-fitness-for-human-habitation/download):
       
   Problem | Sanitary Code


### PR DESCRIPTION
Checking other form filling websites it seems that rather than referring to their product as a tool, website or program, they just the name of the product. I like this idea and so changed website or tool everywhere I could find to UpToCode. 

[Issue #445 ](https://github.com/LemmaLegalConsulting/docassemble-HousingCodeChecklist/issues/445)