### PR TITLE
Pl giving user options in triage

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/Repair_Demand_Letter_to_include.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/Repair_Demand_Letter_to_include.yml
@@ -541,10 +541,10 @@ subject: |
   What if the problems happened at different times?
 content: |
   % if person_answering == "tenant":
-  Use this tool to come up with your best estimate of the
+  Use UpToCode to come up with your best estimate of the
   amount to ask for. It does not need to be exact.
   % else:
-  Use this tool to come up with the tenant's best estimate of the amount to as for. It does not need to be exact.
+  Use UpToCode to come up with the tenant's best estimate of the amount to as for. It does not need to be exact.
   % endif
 ---
 depends on:

--- a/docassemble/HousingCodeChecklist/data/questions/Repair_Letter_Tenant.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/Repair_Letter_Tenant.yml
@@ -83,15 +83,15 @@ subquestion: |
   % endif
 
 fields:
-  - To continue, you must accept the [terms of use](https://massaccess.suffolklitlab.org/privacy/): acknowledged_information_use
+  - To continue, you must accept the [Terms of Use](https://massaccess.suffolklitlab.org/privacy/): acknowledged_information_use
     datatype: checkboxes
     none of the above: False    
     minlength: 1
     choices:
-      - I accept the terms of use.
+      - I accept the Terms of Use.
     validation messages:
       minlength: |
-        You cannot continue unless you agree to the terms of use.        
+        You cannot continue unless you agree to the Terms of Use.        
 continue button field: custom_intro
 terms:
   green words: |

--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -240,13 +240,13 @@ subject: |
 content: |
   % if person_answering == "tenant":
   Your landlord's contact information will be written
-  on the documents that this website creates.
+  on the documents that UpToCode creates.
 
   The court may use the number or email to pick a time
   for you and your landlord to come into court.
   % else:
   The landlord's contact information will be written
-  on the documents that this website creates.
+  on the documents that UpToCode creates.
 
   The court may use the number or email to pick a time
   for the tenant and their landlord to come into court.
@@ -673,9 +673,9 @@ content: |
   you need to be able to tell your landlord and the court where the problem
   is.
   
-  You can use this website to record problems and upload pictures.
+  You can use UpToCode to record problems and upload pictures.
   
-  You could also:
+  You can also:
   
   * Use your phone or a camera to take pictures of the problems.
   * Use a thermometer or a photo of your thermostat and write down the
@@ -688,18 +688,16 @@ template: how_to_notify_landlord_template
 subject: |
   Notify your landlord
 content: |
-  Your landlord is only responsible to fix problems that they know about.
-  Make sure your landlord knows about problems in your house by telling them,
-  even if you think that they should already know.
+  Your landlord is responsible for fixing only the problems they know about.
+  Make sure you tell your landlord about problems in your home, even if you think they should already know.
   
-  Use a way to tell your landlord that you can track and prove.
+  Tell your landlord about the problems in a way that you can prove you told them.
   
-  * Write your landlord a text message.
-  * Write a letter on paper, and keep a copy for yourself. Make sure the date
-    is on the letter.
-  * Write an email.
+  * Text your landlord. Keep the text or a screenshot of the text on your phone.
+  * Write a letter. Make sure to put the date on the letter. Keep a copy for yourself. 
+  * Email your landlord.
   
-  You can use this website to tell your landlord about the problems in your
+  You can use UpToCode to tell your landlord about the problems in your
   home.
 ---
 template: get_inspection_template
@@ -722,8 +720,8 @@ content: |
   
   In other cities and towns, call the Board of Health.
   
-  Before calling the inspector, use this website to create and print a list of 
-  the problems that you have identified. This will help make sure that the
+  Before you call the inspector, use UpToCode to create and print a list of 
+  the problems that you have identified. This will help make sure the
   inspector does not miss any problems.
 
   [Learn more](https://www.masslegalhelp.org/housing/lt1-chapter-8-getting-inspection).
@@ -1138,10 +1136,10 @@ content: |
 
   <h3 class="h5">You need to know</h3>
 
-  * **This website does not provide legal advice**. If you need legal advice, you can use the [Massachusetts Legal Resource Finder](https://masslrf.org) to find a lawyer.
-  * The information and documents on this website have no warranty. We provide the information “as-is.” By using the site, you agree not to hold GBLS or the information providers on this site liable.
-  * We work hard to keep the information on the site up to date. Lawyers drafted and reviewed the documents this site uses. But laws and local rules change over time. These changes can make a document unenforceable when you use it.
-  * We do our best to keep the site working! To do that, we allow you to submit feedback so we can track problems on the site. But we cannot provide individual technical support.
+  * **UpToCode does not provide legal advice**. If you need legal advice, you can use the [Massachusetts Legal Resource Finder](https://masslrf.org) to find a lawyer.
+  * The information and documents on UpToCode have no warranty. We provide the information “as-is.” By using UpToCode, you agree not to hold GBLS or the information providers on UpToCode liable.
+  * We work hard to keep the information on UpToCode up to date. Lawyers drafted and reviewed the documents UpToCode uses. But laws and local rules change over time. These changes can make a document unenforceable when you use it.
+  * We do our best to keep UpToCode working! To do that, we allow you to submit feedback so we can track problems on UpToCode. But we cannot provide individual technical support.
 
   <h3 class="h5">To use this site</h3>
 
@@ -1155,8 +1153,8 @@ content: |
   * We collect the information that you type to help you complete your forms. We delete all information 180 days after you last update it. You can also delete information immediately.
   * We log information including IP addresses and web browsers from all visitors. We use this information to keep our site secure. We keep logs for up to 180 days.
   * We use Google Maps to help fill in addresses automatically. This feature sends your IP address to Google Maps to get your approximate location.
-  * We use Google Analytics to learn how people use our website. This helps us understand which pages are hardest to use. Google may use this information to show you better advertisements.
-  * We use email and text message delivery services that may keep their own records of any messages you send. If you choose to log in with your phone number, this may include a record of the times you log in to the site.
+  * We use Google Analytics to learn how people use UpToCode. The analytics help us understand which pages are hardest to use. Google may use this information to show you better advertisements.
+  * We use email and text message delivery services that may keep their own records of any messages you send. If you choose to log in with your phone number, this may include a record of the times you log in to UpToCode.
 
   <h3 class="h5">We keep your information safe</h3>
 

--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -730,26 +730,25 @@ template: how_to_defend_eviction_template
 subject: |
   Stop your eviction
 content: |
-  Sometimes a landlord will file an eviction case against a tenant if they
-  complain about problems in their house.
+  Sometimes a landlord will file an eviction case against a tenant if the tenant
+  complains about problems in their home. 
   
-  This is illegal. In Massachusetts, evicting a tenant because they complained
+  In Massachusetts, evicting a tenant because they complain
   about bad housing conditions or other housing problems is called
-  "retaliation". [Law about retaliation](https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction).
+  "retaliation". [Law about retaliation](https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction). Retaliation is against the law.
   
   Even if your landlord is not evicting you **because** you complained about
   problems in your house, the problems may be a defense to your eviction.
-  [239 &sect; 
-  8A](https://malegislature.gov/Laws/GeneralLaws/PartIII/TitleIII/Chapter239/Section8A) 
+  [239 &sect; 8A](https://malegislature.gov/Laws/GeneralLaws/PartIII/TitleIII/Chapter239/Section8A) 
   makes bad housing conditions a defense to an eviction if:
   
   1. The eviction is for nonpayment of rent or for no reason.
   1. The problems threaten the health and safety of someone who lives in the
     apartment.
-  1. The landlord knew about the problems at a time that the tenant did not
+  1. The landlord knew about the problems when the tenant did not
   owe any rent.
-  1. The problems were not caused by the tenant.
-  1. The problems can be fixed without the tenant moving out permanently.
+  1. The tenant did not cause the problems.
+  1. Fixing the problems do not require the tenant to move out permanently.
   
   You can defend against your eviction with MADE, Massachusetts Defense
   Against Eviction.

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -823,9 +823,27 @@ subquestion: |
     <h2 class="h4 alert-heading"><i class="fa-solid fa-circle-info"></i> Did you know?</h2>
     <p class="h-100 overflow-visible mb-0">
     % if person_answering == "tenant":
-    "Retaliation" is illegal. Your landlord cannot evict you <b>or</b> raise your rent just because you complain about problems in your home. 
+    "Retaliation" is illegal.
+    If you complain about problems in your home and your landlord tries to get back at you, they are breaking the law. It is against the law to 
+    <ul>
+    <li>evict you, <strong>or</strong></li>
+    <li>raise your rent, </li> 
+    </ul>
+     because you complained.
+     <br> <br>   
+     Read more about illegal <a class="alert-link" href="https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction#retaliatoryevictions" target="_blank" rel="noopener noreferrer">eviction</a> and <a class="alert-link"href="https://www.masslegalhelp.org/housing/lt1-chapter-5-retaliatory-rent-increase target="_blank" rel="noopener noreferrer">rent increases</a> on MassLegalHelp.
+    </p>
     % else:
-    "Retaliation" is illegal. The tenant's landlord cannot evict them or raise their rent just because they complain about problems in their home. 
+    "Retaliation" is illegal. 
+    If the tenant complains about problems in their home and their landlord tries to get back at them, the landlord is breaking the law. It is against the law to 
+    <ul>
+    <li>evict a tenant, <strong>or</strong></li>
+    <li>raise their rent, </li> 
+    </ul>
+     because they complained.
+     <br> <br>   
+     Read more about illegal <a class="alert-link" href="https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction#retaliatoryevictions" target="_blank" rel="noopener noreferrer">eviction</a> and <a class="alert-link"href="https://www.masslegalhelp.org/housing/lt1-chapter-5-retaliatory-rent-increase target="_blank" rel="noopener noreferrer">rent increases</a> on MassLegalHelp.
+    </p>
     % endif
     <a class="alert-link" href="https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction" target="_blank" rel="noopener noreferrer">Read more</a>.
     </p>
@@ -1507,9 +1525,8 @@ validation code: |
     document_choice["contempt_complaint"] = False
 terms:
   retaliated: |
-    Retaliation could include evicting you or raising your rent because you
-    complained about housing problems. Retaliation is illegal and you have
-    protections in a court.
+    Retaliation includes evicting you or raising your rent because you
+    complained about housing problems. Retaliation is against the law. The court can protect you from retaliation.
 ---
 # Set a default value for all document choices
 variable name: document_choice

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -480,15 +480,15 @@ subquestion: |
 
   ${ display_template(about_page_contents, scrollable=True, collapse=True) }
 fields:
-  - To continue, you must accept the terms of use: acknowledged_information_use
+  - To continue, you must accept the Terms of Use: acknowledged_information_use
     datatype: checkboxes
     none of the above: False    
     minlength: 1
     choices:
-      - I accept the terms of use.
+      - I accept the Terms of Use.
     validation messages:
       minlength: |
-        You can only continue if you agree to the terms of use.
+        You can only continue if you agree to the Terms of Use.
 ---
 event: initial_action
 code: |

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -830,8 +830,6 @@ subquestion: |
     <li>raise your rent, </li> 
     </ul>
      because you complained.
-     <br> <br>   
-     Read more about illegal <a class="alert-link" href="https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction#retaliatoryevictions" target="_blank" rel="noopener noreferrer">eviction</a> and <a class="alert-link"href="https://www.masslegalhelp.org/housing/lt1-chapter-5-retaliatory-rent-increase target="_blank" rel="noopener noreferrer">rent increases</a> on MassLegalHelp.
     </p>
     % else:
     "Retaliation" is illegal. 
@@ -840,12 +838,10 @@ subquestion: |
     <li>evict a tenant, <strong>or</strong></li>
     <li>raise their rent, </li> 
     </ul>
-     because they complained.
-     <br> <br>   
-     Read more about illegal <a class="alert-link" href="https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction#retaliatoryevictions" target="_blank" rel="noopener noreferrer">eviction</a> and <a class="alert-link"href="https://www.masslegalhelp.org/housing/lt1-chapter-5-retaliatory-rent-increase target="_blank" rel="noopener noreferrer">rent increases</a> on MassLegalHelp.
+     because they complained.     
     </p>
     % endif
-    <a class="alert-link" href="https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction" target="_blank" rel="noopener noreferrer">Read more</a>.
+    Read more about illegal <a class="alert-link" href="https://www.masslegalhelp.org/housing/lt1-chapter-12-illegal-eviction#retaliatoryevictions" target="_blank" rel="noopener noreferrer">eviction</a> and <a class="alert-link"href="https://www.masslegalhelp.org/housing/lt1-chapter-5-retaliatory-rent-increase target="_blank" rel="noopener noreferrer">rent increases</a> on MassLegalHelp.
     </p>
   </div>
 continue button field: intro_terms_of_use  

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -452,7 +452,7 @@ question: |
   Find ways to get the problems in your home fixed
 subquestion: |
   <div class="alert alert-secondary h-100 mh-100" role="alert">
-    <h2 class="h4 alert-heading"><i class="fa-solid fa-signs-post"></i> How this tool works</h2>
+    <h2 class="h4 alert-heading"><i class="fa-solid fa-signs-post"></i> How UpToCode works</h2>
     <p class="h-100 overflow-visible mb-0">
 
   On the next few screens you can:
@@ -710,23 +710,18 @@ template: when_does_8a_apply
 subject: |
   When can a problem stop my eviction?
 content: |
-  If you are being evicted only because:
+  If your landlord owes you at least $1 because of a repair they did not make or they broke another landlord-tenant law.[239 &sect; 8A](https://www.masslegalhelp.org/housing/lt1-chapter-12-legal-defenses-counterclaims-article) gives you the right to "buy back" your home.
+  
+  239 &sect; 8A may protect you if you are being evicted only because:
 
-  * you owe rent, or
-  * your landlord only wants you to move out and is not saying it is your fault
+  * You owe rent. Or
+  * Your landlord wants you to move out, but not because of anything you did wrong.
 
-  you may be protected from eviction by [239 &sect; 8A](https://www.masslegalhelp.org/housing/lt1-chapter-12-legal-defenses-counterclaims-article).
+  You do not have this right if your landlord is evicting you because of a "fault" reason, like breaking any other rule in your lease. 
 
-  239 &sect; 8A gives you the right to "buy back" your home if your landlord owes you
-  at least $1 because of a repair that they did not make or they violated another 
-  landlord-tenant law.
-
-  You cannot use this right if your landlord is evicting you because of a "fault" reason,
-  such as breaking a rule in your lease other than being behind in the rent.
-
-  You can use the "buy back" right to stop an eviction if you raise it in your eviction
-  case. You need to file an eviction answer using [MADE](https://gbls.org/MADE) to claim
-  it instead of using this website.
+  You can use your "buy back" right to stop an eviction if you raise it in your eviction case. 
+  
+  Use [MADE](https://gbls.org/MADE) to claim this right in your eviction answer. UpToCode does not help with writing an answer.
 ---
 id: warn against suing
 question: |
@@ -739,7 +734,7 @@ subquestion: |
 
   - If the problem is in a public part of your building, or
   - The problem existed before you moved in, or
-  - Your landlord came to your apartment for another reason and had a chance to see the problem
+  - Your landlord came to your apartment for another reason and had a chance to see the problem.
 fields:
   - What do you want to do?: confirm_suing_choice
     datatype: radio
@@ -752,13 +747,13 @@ question: |
   Calling an inspector
 subquestion: |
   It is usually a good idea to call a housing inspector if you sue your
-  landlord. The court will pay attention to the problems that the inspector
-  found. The report that the inspector writes may be evidence in your case.
+  landlord. The court will pay attention to the problems the inspector
+  finds. The report the inspector writes may be evidence in your case.
 
-  You do not have to call an inspector before you use this website but you may want to
-  get the inspection before you deliver the papers to court.
+  You do not have to call an inspector before you use UpToCode. But you may want to
+  get an inspection report before you file your papers at court.
 
-  If it is an emergency you do not have to wait.
+  If it is an emergency you do not have to wait for an inspection report.
 fields:
   - Do you want to include a letter to your city or town inspector?: add_inspection_letter
     datatype: yesnoradio
@@ -842,7 +837,7 @@ id: track conditions intro
 question: |
   List your housing problems
 subquestion: |
-  This website will help you make your list.
+  UpToCode will help you make your list.
 continue button field: track_conditions_intro  
 ---
 id: learn more
@@ -1679,9 +1674,9 @@ subquestion: |
   % endif
   1. Deliver the court forms to the ${ trial_court } at ${ trial_court.address.on_one_line() }. You can call the court for instructions at ${ tel(trial_court.phone_number) }.
   % if person_answering == "tenant":
-  1. You can come back to this website later to take additional steps.
+  1. You can come back to UpToCode later to take additional steps.
   % else:
-  1. The tenant can come back to this website later to take additional steps.
+  1. The tenant can come back to UpToCode later to take additional steps.
   % endif
   % if showifdef("interview_order_request_housing_inspection") and person_answering == "tenant":
 
@@ -1941,11 +1936,11 @@ fields:
   - note: |
       % if person_answering == "tenant":
       **Okay**. You need your landlord's address for many of the forms on
-      this website. You can still finish this form but you will need to add
+      UpToCode. You can finish this form but you will need to add
       your landlord's address before you deliver the form.
       % else:
       **Okay**. The tenant needs their landlord's address for many of the forms on
-      this website. You can still finish this form but the tenant will need to add
+      UpToCode. You can finish this form but the tenant will need to add
       their landlord's address before the tenant delivers the form.
       % endif
     show if: ll_address_unknown       
@@ -2161,18 +2156,18 @@ back button label: |
 template: about_this_interview_version_info
 content: |
   UpToCode is a free website that gives tenants the power to solve
-  landlord problems. It's funded by the national Legal Services Corporation and
+  landlord problems. It is funded by the national Legal Services Corporation and
   Massachusetts nonprofits.
   
   UpToCode does not share any personal identifying information with the government or any other entity. 
 
-  UpToCode includes a translated and easy to read English version of the Massachusetts
-  Sanitary Code, the law that lists the requirements that Massachusetts landlords
-  must follow. It helps tenants:
+  UpToCode includes a translated and easy-to-read English version of the Massachusetts
+  Sanitary Code, the law that lists the requirements Massachusetts landlords
+  must follow. UpToCode helps tenants:
   
-  1. discover their rights under the law,
-  1. report problems to their landlord, a city housing inspector, or the court,
-  1. get a court order to enforce repairs or to get compensation for illegal landlord
+  1. Discover their rights under the law.
+  1. Report problems to their landlord, a city housing inspector, or the court,
+  1. Ask a court for an order to enforce repairs or get compensation for illegal landlord
   actions.
 
   UpToCode was originally authored by Quinten Steenhuis in 2021 in
@@ -2187,7 +2182,7 @@ content: |
   
   Community organizations [La Colaborativa](https://la-colaborativa.org) and
   [Lynn United for Change](https://lynnunited.org) played a special role in
-  co-design of this website.
+  co-design of UpToCode.
 
   &copy; 2022 Northeast Legal Aid, Quinten Steenhuis and open source
   contributors under an [MIT license](https://opensource.org/licenses/MIT).  

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -87,7 +87,7 @@ code: |
     nav.set_section('review_conditions')
     kind_of_lawsuit
     set_document_choice_by_lawsuit_kind
-    if initial_screen_tenant_facing_eviction:
+    if initial_screen_tenant_facing_eviction in('pending', 'has case'):
       warn_eviction
     if kind_of_lawsuit.any_true("get_emergency_repairs", "past_repair_needs"):
       if not tenant_sent_ll_notice:
@@ -444,12 +444,13 @@ fields:
       - I accept the Terms of Use.
     validation messages:
       minlength: |
-        You cannot continue unless you agree to the Terms of Use.
+        You can only continue if you agree to the Terms of Use.
 
 ---
+id: How UpToCode works
 continue button field: intro_and_terms_of_use
 question: |
-  Find ways to get the problems in your home fixed
+  Get the problems in your home fixed
 subquestion: |
   <div class="alert alert-secondary h-100 mh-100" role="alert">
     <h2 class="h4 alert-heading"><i class="fa-solid fa-signs-post"></i> How UpToCode works</h2>
@@ -459,7 +460,7 @@ subquestion: |
 
   <ol>
   <li>
-    List the problems in each room of your home. You can add dates and photos, too.
+    Make a list of the problems in each room of your home. You can add dates and photos too.
   </li>
   <li>
   Answer questions to help you:
@@ -480,7 +481,7 @@ subquestion: |
 
   ${ display_template(about_page_contents, scrollable=True, collapse=True) }
 fields:
-  - To continue, you must accept the Terms of Use: acknowledged_information_use
+  - To continue, you must accept the Terms of Use.: acknowledged_information_use
     datatype: checkboxes
     none of the above: False    
     minlength: 1
@@ -664,24 +665,21 @@ question: |
   Before you take your landlord to court
 fields:
   - Do you have an active eviction case in court?: initial_screen_tenant_facing_eviction
-    datatype: yesnoradio
-    help: |
-      Answer "yes" if:
-      
-      - you have a case that is already in court, or
-      - you have a "Summons and Complaint" from your landlord with a court date coming up
-      
-      Answer "no" if:
-      
-      - there is no eviction case,
-      - the eviction case is already over, or
-      - you only have a "Notice to Quit" or "Notice to Terminate Tenancy"
-  - Does your landlord know about the problems that you need them to fix?: tenant_sent_ll_notice
+    input type: radio
+    choices:
+      - 'There is no eviction case.': no case
+      - 'I got a "Notice to Quit" or a "Notice to Terminate Tenancy", but nothing more.': notice only
+      - 'I got a "Summons and Complaint" from my landlord and I have a court date coming up.': pending
+      - 'I am in an eviction court case now.': has case
+      - 'My eviction case is already over.': closed
+  - note: |
+      **Respond with your Answer to the eviction.** Use [MADE](https://gbls.org/MADE) to help you build your Answer. Do not start a new court case with UpToCode.
+  - Does your landlord already know about the problems in your home?: tenant_sent_ll_notice
     datatype: yesnoradio
     show if:
       code: |
         kind_of_lawsuit.any_true("get_emergency_repairs", "past_repair_needs")
-  - Have you called a town or city inspector about the problem?: tenant_called_inspector
+  - Did you report any problems to your town or city inspector?: tenant_called_inspector
     datatype: yesnoradio
     show if:
       code: |
@@ -945,15 +943,15 @@ content: |
 id: review simple conditions
 question: |
   % if person_answering == "tenant":
-  Do you want to keep exploring problems?
+  Do you want to add more problems to your list?
   % else:
-  Does the tenant want to keep exploring problems?
+  Does the tenant want to add more problems to their list?
   % endif
 subquestion: |
   % if person_answering == "tenant":
-  **You have told us about the following problems:**
+  **You told us about these problems:**
   % else:
-  **You have told us that the tenant has had the following problems:**
+  **You told us the tenant had these problems:**
   % endif
   
   % for basis in kind_of_lawsuit.true_values():
@@ -1020,8 +1018,8 @@ fields:
   - Add more problems?: wants_detailed_conditions
     datatype: radio
     choices:
-      - ${"Yes, see more problems I may have in each room" if person_answering == "tenant" else "Yes, see more problems the tenant may have in each room"}: True
-      - No, go straight to a solution: False
+      - ${"Yes, see more problems I may have in each room." if person_answering == "tenant" else "Yes, see more problems the tenant may have in each room."}: True
+      - No, go straight to a solution.: False
 ---
 template: how_many_problems_are_there_template
 subject: |
@@ -1034,11 +1032,11 @@ content: |
   % if person_answering == "tenant":
   You can pick from a list of about
   150 problems organized by room and category. Some problems you may not know your
-  landlord needs to fix.
+  landlord must fix.
   % else:
   The tenant can pick from a 
   list of about 150 problems organized by room and category. Some problems the tenant may
-  not know their landlord needs to fix.
+  not know their landlord must fix.
   % endif
 
   The list of problems comes from the State Sanitary Code. We put the Code into sentences
@@ -1051,21 +1049,16 @@ question: |
   Look at problems by room and category
 subquestion: |
   % if len(bad_conditions) > 1 and person_answering == "tenant":
-  You have already listed problems in these rooms and categories:
+  You already listed problems in these rooms and categories:
   
   % for button in bad_conditions:
   * [:pencil-alt: ${ str(button).capitalize() }](${ url_action('bad_conditions["' + button + '"].claims') } )
   % endfor
   % endif
-  % if person_answering == "tenant":
-  Your home is protected by the [State Sanitary 
-  Code](https://www.mass.gov/doc/105-cmr-410-state-sanitary-code-chapter-ii-minimum-standards-of-fitness-for-human-habitation/download).
-  % else:
-  The tenant's home is protected by the [State Sanitary 
-  Code](https://www.mass.gov/doc/105-cmr-410-state-sanitary-code-chapter-ii-minimum-standards-of-fitness-for-human-habitation/download).
   
-  Select a room or category to add a problem.
-  % endif
+  
+  Pick a room or category to add another problem.
+  
 field: bad_conditions.new_item_name
 buttons:
   code: |
@@ -1346,181 +1339,168 @@ fields:
       Does the tenant have an active eviction case in court?
       % endif
     field: screen_tenant_facing_eviction
-    datatype: yesnoradio
-    help: |
-      % if person_answering == "tenant":
-      
-      Answer "yes" if:
-      
-      - you have a case that is already in court, or
-      - you have a "Summons and Complaint" from your landlord with a court date coming up
-      
-      Answer "no" if:
-      
-      - there is no eviction case
-      - the eviction case is already over, or
-      - you only have a "Notice to Quit" or "Notice to Terminate Tenancy"
-      % else:
-      Answer "yes" if:
-      
-      - the tenant has a case that is already in court, or
-      - the tenant has a "Summons and Complaint" from the landlord with a court date coming up
-      
-      Answer "no" if:
-      
-      - there is no eviction case
-      - the eviction case is already over, or
-      - the tenant only has a "Notice to Quit" or "Notice to Terminate Tenancy"
-      % endif
+    input type: radio
+    choices:
+      - There is no eviction case.: no case
+      - ${'I got a "Notice to Quit" or a "Notice to Terminate Tenancy", but nothing more.' if person_answering == "tenant" else 'The tenant got a "Notice to Quit" or a "Notice to Terminate Tenancy", but nothing more.'}: notice only
+      - ${'I got a "Summons and Complaint" from my landlord and I have a court date coming up.' if person_answering == "tenant" else 'The tenant got a "Summons and Complaint" from their landlord and they have a court date coming up.'}: pending
+      - ${"I have a case that is already in court." if person_answering == "tenant" else "The tenant has a case that is already in court."}: has case
+      - The eviction case is finished.: closed
   - note: |
       % if person_answering == "tenant":
-      **Make sure you respond to the eviction.** You can use [MADE](https://gbls.org/MADE) to 
-      stop the eviction case. You shouldn't start a new court case with UpToCode.
+      **Make sure you respond to the eviction.** You can use [MADE](https://gbls.org/MADE) to stop the eviction case. Do not use UpToCode to start a new court case while you have an active eviction.
       % else:
-      **Make sure the tenant responds to the eviction. **They can use [MADE](https://gbls.org/MADE) to 
-      stop the eviction case. The tenant shouldn't start a new court case with UpToCode.
+      **Make sure the tenant responds to the eviction. **They can use [MADE](https://gbls.org/MADE) to stop the eviction case. The tenant should not use UpToCode to start a new court case while they have an active eviction.
       % endif
-    show if: screen_tenant_facing_eviction
+    js show if:
+      val("screen_tenant_facing_eviction") == 'has case' || val("screen_tenant_facing_eviction") =='pending'
   - label: |
       % if person_answering == "tenant":
-      Does your landlord already know about at least one of the problems in your home?   
+      Does your landlord know about the problems in your home?   
       % else:
-      Does the tenant's landlord already know about at least one of the problems in the tenant's home?
+      Does the landlord know about the problems in the tenant's home?
       % endif
     field: screen_ll_knows_problem
     datatype: yesnoradio
   - note: |
       % if person_answering == "tenant":
-      **Okay.** Your first step should be to tell your landlord about the
-      problem. We can help you write a letter to tell your landlord and put
-      them on legal notice.
+      **Okay.** First, tell your landlord about the problem. We can help you write a letter to your landlord that gives them 'legal notice'.
       % else: 
-      **Okay.** The tenant's first step should be to tell their landlord about the
-      problem. We can help write a letter to tell their landlord and put
-      them on legal notice.
+      **Okay.** First, the tenant should tell their landlord about the problem. We can help write a letter to their landlord that gives their landlord 'legal notice'.
       % endif
     show if:
       variable: screen_ll_knows_problem
-      is: False
+      is: False 
   - label: |
       % if person_answering == "tenant":
-      Is your landlord already fixing all of the problems?
+      Is your landlord already fixing all the problems?
       % else:
-      Is the tenant's landlord already fixing all of the problems?
+      Is the tenant's landlord already fixing all the problems?
       % endif
     field: screen_ll_already_fixing 
     datatype: yesnoradio
     show if: screen_ll_knows_problem
   - note: |
       % if person_answering == "tenant":
-      **You may want to give your landlord time.** Some serious problems
-      need to be fixed in 24 hours, and others problems must be fixed in up to 30 days.
-      
-      If you have not given your landlord enough time to fix the problem yet,
-      you may want to wait before you get help from a court. But it is up
-      to you.
+      **You may want to give your landlord some time.** Your landlord must fix some serious problems in 24 hours. Other problems are not so urgent and your landlord may have up to 30 days to fix them.
+
+      If you have not given your landlord enough time to fix the problem, you may want to wait before you ask the court for help. But it is up to you.
       % else:
-      **The tenant may want to give their landlord time.** Some serious problems
-      need to be fixed in 24 hours, and others problems must be fixed in up to 30 days.
-      
-      If the tenant has not given their landlord enough time to fix the problem yet,
-      the tenant may want to wait before they get help from a court. But it is up
-      to them.
+      **The tenant may want to give their landlord some time.** The landlord must fix some serious problems in 24 hours. Other problems are not so urgent and your landlord may have up to 30 days to fix them.
+
+      If the tenant has not given their landlord enough time to fix the problem,
+      the tenant may want to wait before they ask the court for help. But it is up
+      to the tenant.
       % endif
     show if: screen_ll_already_fixing
+
   - label: |
       % if person_answering == "tenant":
-      Are other tenants in your building also having housing problems?
+      Do other tenants in your building have housing problems also?
       % else:
-      Are other tenants in ${ users.familiar() }'s building also having housing problems?
+      Do other tenants in the tenant's building have housing problems also?
       % endif
     field: screen_other_tenants_with_problem
     datatype: yesnomaybe
     show if: screen_ll_knows_problem
   - note: |
       % if person_answering == "tenant":
-      **${ users.familiar() }, you and your neighbors are stronger together**. You have the right to **organize** with other tenants to fight the bad housing conditions.
+      **${ users.familiar() }, you and your neighbors are stronger together**. You have the right to **organize** with other tenants and get your landlord to fix these problems.
       % else:
-      **The tenant, and their neighbors are stronger together**. They have the right to **organize** with other tenants to fight the bad housing conditions.
+      **The tenant, and their neighbors are stronger together**. They have the right to **organize** with other tenants and get their landlord to fix these problems.
       % endif
-    show if: screen_other_tenants_with_problem
+    js show if: |
+      val('screen_other_tenants_with_problem') === true || val('screen_other_tenants_with_problem') === 'None'
+
   - label: |
-      % if person_answering == "tenant":
-      Have you reported all of the problems to a city housing inspector? 
-      % else:
-      Has the tenant reported all of their problems to a city housing inspector?
-      % endif
+        % if person_answering == "tenant":
+        Did you report any problems to your town or city housing inspector? 
+        % else:
+        Did the tenant report any problems to their town or city housing inspector?
+        % endif
     field: screen_contacted_housing_inspector
     datatype: yesnoradio
     show if: screen_ll_knows_problem
   - note: |
       % if person_answering == "tenant":
-      **You may want to get an inspection.** You have the option to get one below. You are not required to get a
+      **You may want to get an inspection.** You do not have to get a
       housing inspection. But it can help a judge understand the problems
-      better. You do not need to wait for the inspection to get more help.
+      better. You do not need to wait for the inspection to ask for more help.
       % else:
-      **The tenant may want to get an inspection.** The tenant has the option to get one below. The tenant is not required to get a
+      **The tenant may want to get an inspection.** The tenant does not have to get a
       housing inspection. But it can help a judge understand the problems
-      better. The tenant does not need to wait for the inspection to get more help.
+      better. The tenant does not need to wait for the inspection to ask for more help.
       % endif
     show if:
       variable: screen_contacted_housing_inspector
       is: False
-  - Did a judge already order your landlord to do something about your case?: has_tro
+  - label: |
+        % if person_answering == "tenant":
+        Did a judge already order your landlord to do something in your case?
+        % else: 
+        Did a judge already order the tenant's landlord to do something in the case?
+        % endif
+    field: has_tro
     datatype: yesnoradio
     show if: screen_ll_knows_problem
   - note: |
-      **You may want to tell a judge if your landlord is ignoring the judge's order.** This is called a Contempt Complaint. You have the option to get one below.
+      % if person_answering == "tenant":
+      **You may want more help from the court if your landlord is ignoring a court order.** You can file a Complaint for Contempt.
+      % else:
+      **The tenant may want more help from the court if their landlord is ignoring a court order.** They can file a Complaint for Contempt.
+      % endif
     show if: has_tro
   - note: |
       % if person_answering == "tenant":
-      **What would you like to do?**
-      Remember, you have the right not to be {retaliated} against. 
+      **What do you want to do?**
+      Remember, you have the right to be protected from {retaliation}. 
       % else:
-      **What would the tenant like to do?**    
-      Remember, the tenant has the right not to be {retaliated} against.
+      **What does the tenant want to do?**    
+      Remember, the tenant has the right to be protected from {retaliation}.
       % endif
-    show if: screen_ll_knows_problem      
+    show if: screen_ll_knows_problem
+        
   - no label: document_choice
     required: False
     datatype: checkboxes
     js show if: |
       val("screen_ll_knows_problem") && !val("has_tro")
     choices:
-      - ${"Save or print a copy of my checklist for later" if person_answering == "tenant" else "Save or print a copy of the tenant's checklist for later"}: get_report
-      - ${"Tell my landlord about the problems" if person_answering == "tenant" else "Tell the tenant's landlord about the problems"}: tell_landlord
-      - ${"Organize with my neighbors or other tenants in my city" if person_answering == "tenant" else "Organize with the tenant's neighbors or other tenants in their city"}: organize_tenants
+      - ${"Save or print a copy of my checklist for later." if person_answering == "tenant" else "Save or print a copy of the tenant's checklist for later."}: get_report
+      - ${"Tell my landlord about the problems." if person_answering == "tenant" else "Tell the tenant's landlord about the problems."}: tell_landlord
+      - ${"Organize with my neighbors or other tenants in my city." if person_answering == "tenant" else "Organize with the tenant's neighbors or other tenants in their city."}: organize_tenants
       - Get a city inspection: get_inspection
-      - Ask for a fair settlement (consumer protection demand letter or settlement letter): demand_letter_93a
-      - ${"Ask a judge to order my landlord to fix a problem or sue my landlord for money" if person_answering == "tenant" else "Ask a judge to order the tenant's landlord to fix a problem or sue the tenant's landlord for money"}: sue_landlord
+      - Ask for a fair settlement. Use a consumer protection demand letter or a settlement letter.: demand_letter_93a
+      - ${"Ask the court to order my landlord to fix a problem or sue my landlord for money." if person_answering == "tenant" else "Ask the court to order the tenant's landlord to fix a problem or sue the tenant's landlord for money."}: sue_landlord
     none of the above: False
     default:
       code: |
         ["get_report"] if kind_of_lawsuit.all_false() else ["get_report", "sue_landlord"]
+  
   - no label: document_choice
     required: False
     datatype: checkboxes
     js show if: |
       val("screen_ll_knows_problem") && val("has_tro")
     choices:
-      - ${"Save or print a copy of my checklist for later" if person_answering == "tenant" else "Save or print a copy of the tenant's checklist for later"}: get_report
-      - ${"Tell my landlord about the problems" if person_answering == "tenant" else "Tell the tenant's landlord about the problems"}: tell_landlord
-      - ${"Organize with my neighbors or other tenants in my city" if person_answering == "tenant" else "Organize with the tenant's neighbors or other tenants in their city"}: organize_tenants
-      - Get a city inspection: get_inspection
-      - Ask for a fair settlement (consumer demand letter): demand_letter_93a
-      - ${"Ask a judge to order my landlord to fix a problem or sue my landlord for money" if person_answering == "tenant" else "Ask a judge to order the tenant's landlord to fix a problem or sue the tenant's landlord for money"}: sue_landlord
-      - ${"Tell a judge that my landlord is ignoring the judge's order" if person_answering == "tenant" else "Tell a judge that the tenant's landlord is ignoring the judge's order"}: contempt_complaint
+      - ${"Save or print a copy of my checklist for later." if person_answering == "tenant" else "Save or print a copy of the tenant's checklist for later."}: get_report
+      - ${"Tell my landlord about the problems." if person_answering == "tenant" else "Tell the tenant's landlord about the problems."}: tell_landlord
+      - ${"Organize with my neighbors or other tenants in my city." if person_answering == "tenant" else "Organize with the tenant's neighbors or other tenants in their city."}: organize_tenants
+      - Get a city inspection.: get_inspection
+      - Ask for a fair settlement, use a consumer demand letter or a settlement letter.: demand_letter_93a
+      - ${"Ask the court to order my landlord to fix a problem or sue my landlord for money." if person_answering == "tenant" else "Ask the court to order the tenant's landlord to fix a problem or sue the tenant's landlord for money."}: sue_landlord
+      - ${"Tell a judge my landlord is ignoring the court order." if person_answering == "tenant" else "Tell a judge the tenant's landlord is ignoring the court order."}: contempt_complaint
     none of the above: False
     default:
       code: |
         ["get_report", "contempt_complaint"] if kind_of_lawsuit["file_contempt_complaint"] else ["get_report"] if kind_of_lawsuit.all_false() else ["get_report", "sue_landlord"]
 validation code: |
   if screen_ll_knows_problem and len(document_choice.true_values()) < 1:
-    validation_error("Select at least one.", field="document_choice")
+    validation_error("Pick at least one.", field="document_choice")
   if screen_ll_knows_problem and "contempt_complaint" not in document_choice:
     document_choice["contempt_complaint"] = False
 terms:
-  retaliated: |
+  retaliation: |
     Retaliation includes evicting you or raising your rent because you
     complained about housing problems. Retaliation is against the law. The court can protect you from retaliation.
 ---

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -229,7 +229,7 @@ id: landing-page
 question: |
   You deserve a safe and decent home
 subquestion: |
-  Need help with repairs or stopping landlord harassment? Select a task to get started.
+  Need help to get repairs or stop your landlord from harassing you? Pick a task.
   
   % if device() and hasattr(device(), "is_mobile") and device().is_mobile:
 
@@ -239,9 +239,9 @@ subquestion: |
     <div class="row g-0">
       <div class="col-md-8">
         <div class="card-body bg-info">
-          <h5 class="card-title"><i class="fa-solid fa-magnifying-glass"></i> Explore problems and solutions</h5>
-          <p class="card-text">Explore problems by room and category and get your landlord to fix them.</p>
-          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start exploring</a>
+          <h5 class="card-title"><i class="fa-solid fa-magnifying-glass"></i> Describe  problems and find solutions</h5>
+          <p class="card-text">List problems by room and category and get your landlord to fix them.</p>
+          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start your list</a>
         </div>
       </div>
     </div>
@@ -304,9 +304,9 @@ subquestion: |
       </div>
       <div class="col-md-8">
         <div class="card-body">
-          <h5 class="card-title">Explore problems and solutions</h5>
-          <p class="card-text">Explore problems by room and category and get your landlord to fix them.</p>
-          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start exploring</a>
+          <h5 class="card-title">Describe  problems and find solutions</h5>
+          <p class="card-text">List problems by room and category and get your landlord to fix them.</p>
+          <a class="btn btn-primary stretched-link align-self-end" href="${ url_action("initial_action", selection="document_by_room") }" role="button">Start your list</a>
         </div>
       </div>
     </div>
@@ -449,7 +449,7 @@ fields:
 ---
 continue button field: intro_and_terms_of_use
 question: |
-  Explore solutions to the problems in your home
+  Find ways to get the problems in your home fixed
 subquestion: |
   <div class="alert alert-secondary h-100 mh-100" role="alert">
     <h2 class="h4 alert-heading"><i class="fa-solid fa-signs-post"></i> How this tool works</h2>
@@ -459,14 +459,14 @@ subquestion: |
 
   <ol>
   <li>
-    Track the problems in each room of your home. You can add dates and photos, too.
+    List the problems in each room of your home. You can add dates and photos, too.
   </li>
   <li>
   Answer questions to help you:
   <ul>
-  <li>write your landlord a letter,</li>
-  <li>ask the city for an inspection, or</li>
-  <li>ask a judge to order your landlord to fix the problem.</li>
+  <li>Write a letter to your landlord.</li>
+  <li>Ask the city for an inspection. Or</li>
+  <li>Ask a judge to order your landlord to fix the problem.</li>
   </ul>
   </li>
   <li>
@@ -840,9 +840,9 @@ continue button label: Get started
 ---
 id: track conditions intro
 question: |
-  Track your housing problems
+  List your housing problems
 subquestion: |
-  This website will help you track.
+  This website will help you make your list.
 continue button field: track_conditions_intro  
 ---
 id: learn more
@@ -1008,10 +1008,10 @@ subquestion: |
   ${ collapse_template(how_many_problems_are_there_template)}
 
 fields:
-  - Keep exploring problems?: wants_detailed_conditions
+  - Add more problems?: wants_detailed_conditions
     datatype: radio
     choices:
-      - ${"Yes, explore problems I may have in each room" if person_answering == "tenant" else "Yes, explore problems the tenant may have in each room"}: True
+      - ${"Yes, see more problems I may have in each room" if person_answering == "tenant" else "Yes, see more problems the tenant may have in each room"}: True
       - No, go straight to a solution: False
 ---
 template: how_many_problems_are_there_template
@@ -1023,24 +1023,23 @@ subject: |
   % endif
 content: |
   % if person_answering == "tenant":
-  If you explore by room and category, you can pick from a list of about
-  150 problems. Some may be problems you did not know your
+  You can pick from a list of about
+  150 problems organized by room and category. Some problems you may not know your
   landlord needs to fix.
   % else:
-  If the tenant explores by room and category, the tenant can pick from a 
-  list of about 150 problems. Some may be problems that the tenant did 
+  The tenant can pick from a 
+  list of about 150 problems organized by room and category. Some problems the tenant may
   not know their landlord needs to fix.
   % endif
 
-  The list of problems comes from the State Sanitary Code. We have
-  translated the Sanitary Code into easier to understand sentences
-  with short explanations.
+  The list of problems comes from the State Sanitary Code. We put the Code into sentences
+  with short explanations so it is easier to understand.
 ---  
 # WARNING: This page id needs to stay the same or the selectors for
 # the button styles in styles.css will need to be updated to match
 id: room chooser
 question: |
-  Explore problems by room and category
+  Look at problems by room and category
 subquestion: |
   % if len(bad_conditions) > 1 and person_answering == "tenant":
   You have already listed problems in these rooms and categories:
@@ -1065,7 +1064,7 @@ buttons:
 back button label: |
   Back
 under: |
-  You can keep exploring problems by room and category, or skip ahead
+  Keep looking at problems by room and category, or skip ahead
   to start working on a solution.
   
   % if len(bad_conditions.elements):
@@ -1125,10 +1124,10 @@ id: Claims
 question: |
   Emergency problems
 subquestion: |
-  Your landlord should start fixing any problem listed below within 24 hours
-  of learning about the problem.
+  Your landlord should start to fix these problems within 24 hours from the time they 
+  learn about the problem.
   
-  If you do not see your problem listed below, try a different room or category.
+  If you do not see the problem you are looking for, try a different room or category.
 
   ${ collapse_template(emergency_sanitary_code_template) }
 fields:
@@ -1145,7 +1144,7 @@ template: emergency_sanitary_code_template
 subject: |
   Related Sanitary Code
 content: |
-  The problems listed below are cited in the following sections of the
+  These problems are listed in the following sections of the
   [Sanitary Code](https://www.mass.gov/doc/105-cmr-410-state-sanitary-code-chapter-ii-minimum-standards-of-fitness-for-human-habitation/download):
       
   Problem | Sanitary Code

--- a/docassemble/HousingCodeChecklist/data/questions/language.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/language.yml
@@ -36,11 +36,11 @@ code: |
 #    <div data-variable="${ encode_name(str( user_info().variable )) }" id="sought_variable" aria-hidden="true" style="display: none;"></div>
 #    % endif  
 ---
-default screen parts:
-    pre: |
-     % if not defined('acknowledged_information_use'):
-     ${ docassemble.AssemblyLine.language.get_language_list(get_tuples(['en','es','pt','ht']),current=user_language) }
-     % endif
+  default screen parts:
+      pre: |
+       % if not defined('acknowledged_information_use'):
+       ${ docassemble.AssemblyLine.language.get_language_list(get_tuples(['en','es','pt','ht']),current=user_language) }
+       % endif
 ---
 depends on:
   - user_language


### PR DESCRIPTION
See[ Issue #442 ](https://github.com/LemmaLegalConsulting/docassemble-HousingCodeChecklist/issues/442)

Give tenants a more specific concrete list of choices rather than requiring they look at help to figure out if htey have an active case or not.

Also tried to make sure id: triage matched text in id: confirm notice - may have to look at this one more time to be sure they are the same. 