### PR TITLE
510-feat-update-contact-info-question-to-include-reasons-for

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -205,6 +205,20 @@ subquestion: |
   The court may need to call the tenant to set up a hearing. If the tenant
   does not have their own phone number or email, they can consider using
   a phone number that belongs to a trusted friend or family member.
+  % elif person_answering == "tenant" and document_choice['get_inspection']:
+  The inspector may need to contact you to set up an inspection of your unit. If you
+  do not have your own phone number or email, consider using
+  a phone number or email that belongs to a trusted friend or family member.
+  % elif person_answering == "attorney" or person_answering == "tenant_helper" and document_choice['get_inspection']:
+  The inspector may need to contact the tenant to set up an inspection of their unit. If the tenant does not have their own phone number or email, they can consider using a phone number or email that belongs to a trusted friend or family member.
+  % elif person_answering == "tenant":
+  Your landlord may need to contact you to set up a time for repairs. If you
+  do not have your own phone number or email, consider using
+  a phone number or email that belongs to a trusted friend or family member.
+  % else:
+  The tenant's landlord may need to contact them to set up a time for repairs. If the tenant
+  does not have their own phone number or email, they can consider using
+  a phone number or email that belongs to a trusted friend or family member.
   % endif
 fields:  
   - Mobile number: users[0].mobile_number


### PR DESCRIPTION
<Type out your reasons for this PR>

Updated the tenant contact info question to have responsive questions for final document types and reasons why they should provide a way to contact.


<Add links to any solved issues here by using closing keywords>
Fixed #510 


### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested a review
