### PR TITLE
499-bug-fixed-issue-where-review-screen-always-said-there-was-an-open-eviction-case

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -2528,9 +2528,9 @@ review:
       - main_triage_screen
     button: |
       % if person_answering == "tenant":
-      You have an active eviction case in court: **${ yesno(screen_tenant_facing_eviction) }**
+      You have an active eviction case in court: **${ "Yes" if screen_tenant_facing_eviction == "pending" or screen_tenant_facing_eviction == "has case" else "No" }**
       % else:
-      The tenant has an active eviction case in court: **${ yesno(screen_tenant_facing_eviction) }**
+      The tenant has an active eviction case in court: **${ "Yes" if screen_tenant_facing_eviction == "pending" or screen_tenant_facing_eviction == "has case" else "No" }**
       % endif
   - Edit: 
       - main_triage_screen


### PR DESCRIPTION
<Type out your reasons for this PR>

Fixed an issue with the review screen always saying "Yes" to open eviction case even when user selected one of the three options for no open eviction case.


<Add links to any solved issues here by using closing keywords>

Fixed #499 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested a review
