### PR TITLE
545-bug-fixed-issue-where-court-location-was-asked-even-for-non-court-documents

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -2034,7 +2034,9 @@ subquestion: |
   1. Read the instructions to learn how to file and deliver the tenant's
   documents.
   % endif
+  % if document_choice["sue_landlord"] or document_choice["contempt_complaint"]:
   1. Deliver the court forms to the ${ trial_court } at ${ trial_court.address.on_one_line() }. You can call the court for instructions at ${ tel(trial_court.phone_number) }.
+  % endif
   % if person_answering == "tenant":
   1. You can come back to UpToCode later to take additional steps.
   % else:


### PR DESCRIPTION
<Type out your reasons for this PR>

Fixed a bug that caused the question about which court the user wanted to file in to be asked even when they were not attempting to file anything.

<Add links to any solved issues here by using closing keywords>

Fixed #545 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested a review
