### PR TITLE
481-refactor-reversed-order-of-court-list-options-and-map

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -964,21 +964,22 @@ question: |
   What court does the tenant want to file in?
   % endif
 subquestion: |
+  % if len(all_matches) > 0:
+  Select an option from the list of court(s) serving the address you gave us,
+    % if isinstance(addresses_to_search, Iterable):
+    ${comma_and_list([address.on_one_line() for address in addresses_to_search],comma_string='; ')}.
+    % else:
+    ${addresses_to_search.on_one_line()}
+    % endif
+  % endif
+  
   Most tenants file in the Housing Court.
 
   ${ collapse_template(housing_how_to_pick_court_help_template) }
-
-  % if len(all_matches) > 0:
-  Below is a map of the court(s) that serve
-  the address you gave us, 
-  % if isinstance(addresses_to_search, Iterable):
-  ${comma_and_list([address.on_one_line() for address in addresses_to_search],comma_string='; ')}.
-  % else:
-  ${addresses_to_search.on_one_line()}
-  % endif
   
+under: |    
+  Below is a map of the court(s) that serve the address you gave us.
   ${map_of(combined_locations(all_matches))}
-  % endif
   
 fields:
   - no label: trial_court
@@ -1003,6 +1004,7 @@ fields:
     show if:
       variable: trial_court
       is: None
+      
 ---
 template: housing_how_to_pick_court_help_template
 subject: |


### PR DESCRIPTION
<Type out your reasons for this PR>

Per usability audit suggestion, reversed the order of the map and list of court options and updated wording to ensure user knows to pick from the provided options and not the map.

<Add links to any solved issues here by using closing keywords>

Fixed #481 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested a review
