### PR TITLE
506-feat-add-warning-screen-for-condemnation

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
@@ -1,0 +1,18 @@
+id: terms
+terms:
+  condemned: |
+    If a unit is condemned the tenants must move out. A unit can be condemned if it is considered to be an illegal unit, is overcrowded, or is found to be uninhabitable by City Inspectors or the Board of Health.
+  illegal unit: |
+    An illegal unit is a unit that the landlord doesn’t have a certificate of occupancy for or a unit that hasn’t been properaly registered with the City or Town.
+  overcrowded: |
+    A rental unit is considered overcrowded if there is not enough space as defined in the MA State Sanitary Code.
+    <br>
+    <br>
+    1. The first person in a unit needs 150 square feet of living space, and each additional person needs 100 square feet of living space. For example, a unit with four people needs 450 square feet of living space.
+    <br>
+    <br>
+    2. The first person in a bedroom needs 70 square feet of bedroom space, and each additional person needs 50 square feet. For example, a bedroom with two people needs 120 square feet of bedroom space.
+  retaliation: |
+    Retaliation includes evicting you or raising your rent because you complained about housing problems. Retaliation is against the law. The court can protect you from retaliation.
+  uninhabitable: |
+    If a housing inspector finds that all or a part of the building you live in is unsuitable to live in and/or repairs cannot be made while you are living in the property, the Board of Health may issue a finding that the dwelling or a portion of the dwelling is unfit for human habitation.

--- a/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
@@ -1,17 +1,13 @@
 id: terms
 terms:
   condemned: |
-    If a unit is condemned the tenants must move out. A unit can be condemned if it is considered to be an illegal unit, is overcrowded, or is found to be uninhabitable by City Inspectors or the Board of Health.
+    If a unit is condemned the tenants must move out. A unit can be condemned if it is considered to be an illegal unit, is overcrowded, or is found to be uninhabitable by Inspectors or the Board of Health.
+  green words: |
+    Green words are legal terms or a short explanation. The definition or explanation pops up when you click the green words.
   illegal unit: |
-    An illegal unit is a unit that the landlord doesn’t have a certificate of occupancy for or a unit that hasn’t been properaly registered with the City or Town.
+    An illegal unit is a unit that hasn’t been properaly registered with the City or Town. Illegal units are often in converted attics or basements of the building that do not meet basic safety or sanitary code standards.
   overcrowded: |
-    A rental unit is considered overcrowded if there is not enough space as defined in the MA State Sanitary Code.
-    <br>
-    <br>
-    1. The first person in a unit needs 150 square feet of living space, and each additional person needs 100 square feet of living space. For example, a unit with four people needs 450 square feet of living space.
-    <br>
-    <br>
-    2. The first person in a bedroom needs 70 square feet of bedroom space, and each additional person needs 50 square feet. For example, a bedroom with two people needs 120 square feet of bedroom space.
+    A rental unit is considered overcrowded if there is not enough space for all of the tenants. Generally, having more than two people per bedroom can be considered overcrowding if the room is not large enough as defined in the MA State Sanitary Code (105 CMR 410.420(D)).
   retaliation: |
     Retaliation includes evicting you or raising your rent because you complained about housing problems. Retaliation is against the law. The court can protect you from retaliation.
   uninhabitable: |

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -16,6 +16,7 @@ include:
   - language.yml
   - simple_conditions.yml
   - orders_and_contempt_complaint.yml
+  - autoterms.yml
 ---
 features:
   bootstrap theme: uptocode.bootstrap.css
@@ -1868,10 +1869,6 @@ validation code: |
     validation_error("Pick at least one.", field="document_choice")
   if screen_ll_knows_problem and "contempt_complaint" not in document_choice:
     document_choice["contempt_complaint"] = False
-terms:
-  retaliation: |
-    Retaliation includes evicting you or raising your rent because you
-    complained about housing problems. Retaliation is against the law. The court can protect you from retaliation.
 ---
 # Set a default value for all document choices
 variable name: document_choice
@@ -1937,6 +1934,7 @@ code: |
   # display_inspector_information
   other_parties[0].name.first
   other_parties[0].address.address
+  condemn_warning
   interview_order_request_housing_inspection = True
 ---
 code: |
@@ -2045,6 +2043,16 @@ subquestion: |
   1. The tenant can come back to UpToCode later to take additional steps.
   % endif
   % if showifdef("interview_order_request_housing_inspection") and person_answering == "tenant":
+  
+  <h2 class="h4">Before submitting your request to inspectional services, please seek legal help if you believe that:</h2>
+  
+  1. You live in an {illegal unit}.
+  1. Your unit is {overcrowded}.
+  1. Your unit is {uninhabitable}.
+  
+  A unit can be {condemned} in these circumstances.
+  
+  Find legal aid organizations in your area by answering a few questions [here](https://masslrf.org/en/triage/start/housing).
 
   <h2 class="h4">To call the housing inspector for your city or town</h2>
   You can call the inspector at ${ tel(inspector_information["Telephone"]) }.
@@ -2055,6 +2063,16 @@ subquestion: |
   ${ collapse_template(detailed_inspector_information_template)}  
   
   % elif showifdef("interview_order_request_housing_inspection"): 
+  
+  <h2 class="h4">Before submitting the tenant's request to inspectional services, please seek legal help if they believe that:</h2>
+  
+  1. They live in an {illegal unit}.
+  1. Their unit is {overcrowded}.
+  1. Their unit is {uninhabitable}.
+  
+  A unit can be {condemned} in these circumstances.
+  
+  Find legal aid organizations in the tenant's area by answering a few questions [here](https://masslrf.org/en/triage/start/housing).
   
   <h2 class="h4">To call the housing inspector for your city or town</h2>
   You can call the inspector at ${ tel(inspector_information["Telephone"]) }.
@@ -2961,3 +2979,30 @@ content: |
   <a href="https://www.lsc.gov/"><img src="${ lsc_logo.url_for() }" style="max-width: 80%" alt="Legal Services Corporation logo"/></a>
 
   <a href="https://www.mlac.org/"><img src="${ mlac_logo.url_for() }" alt="Massachusetts Legal Assistance Corporation logo"/></a>
+---
+id: condemn_warning
+continue button field: condemn_warning
+question: |
+  You may want to wait to submit a request to inspectional services
+subquestion: |
+  % if person_answering == "tenant":
+  A unit can be {condemned} in certain circumstances.
+  
+  **Before submitting your request to inspectional services, please seek legal help if you believe that:**
+  
+  1. You live in an {illegal unit}.
+  1. Your unit is {overcrowded}.
+  1. Your unit is {uninhabitable}.
+  
+  Find legal aid organizations in your area by answering a few questions [here](https://masslrf.org/en/triage/start/housing).
+  % else:
+  A unit can be {condemned} in certain circumstances.
+  
+  **Before submitting a request to inspectional services, please seek legal help if the tenant thinks that:**
+  
+  1. They live in an {illegal unit}.
+  1. Their unit is {overcrowded}.
+  1. Their unit is {uninhabitable}.
+  
+  Find legal aid organizations in the tenant's area by answering a few questions [here](https://masslrf.org/en/triage/start/housing).
+  % endif


### PR DESCRIPTION
<Type out your reasons for this PR>

- Created a warning screen and final warning on the download screen that shows only if the user selects the option for inspection request letter.
- Created YAML file to include auto terms and wrote summary explanations of the current terms in the interview. 

<Add links to any solved issues here by using closing keywords>

Fixed #506 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested a review

<img width="702" alt="Screenshot 2024-10-21 at 11 07 16 AM" src="https://github.com/user-attachments/assets/a9833da4-ac0c-46b1-8fb0-e9b8e10c7c81">
<img width="688" alt="Screenshot 2024-10-21 at 11 14 13 AM" src="https://github.com/user-attachments/assets/1dd53e5c-db13-4725-b94b-f2ffe0095be3">
