### PR TITLE
565-bug-fixed-out-of-order-questions

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -116,8 +116,6 @@ code: |
     interview_order_tenant_repair_request
     nav.set_section(sub_documents['organize_tenants'].get('section_link'))
     organizing_interstitial
-    nav.set_section("preview_and_sign")
-    basic_questions_signature_flow
   else:
     explain_documents
     update_sections_with_selected_documents  
@@ -162,18 +160,12 @@ code: |
       case_name
       docket_numbers
       ask_affidavit_questions
-    nav.set_section('preview_and_sign')
-    uptocode_review
-    basic_questions_signature_flow
   if screen_ll_knows_problem and document_choice["contempt_complaint"]:
     interview_order_contempt_complaint
-    nav.set_section('preview_and_sign')
-    uptocode_review
-    basic_questions_signature_flow
-  if screen_ll_knows_problem and {'get_inspection', 'tell_landlord'}.intersection(document_choice.true_values()):
-    nav.set_section('preview_and_sign')
-    uptocode_review
-    basic_questions_signature_flow
+  
+  nav.set_section('preview_and_sign')
+  uptocode_review
+  basic_questions_signature_flow
   
   reached_download_screen = True
   reconsider('snapshot_interview_state')


### PR DESCRIPTION
<Type out your reasons for this PR>

Updated interview order to have review and signature flow appear only once before download screen instead of in each interview order block based on document selections.

<Add links to any solved issues here by using closing keywords>

Fixed #565 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested a review
