### PR TITLE
604-add-questions-to-trigger-interrogatories

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
@@ -8,6 +8,8 @@ terms:
     An illegal unit is a unit that hasn’t been properaly registered with the City or Town. Illegal units are often in converted attics or basements of the building that do not meet basic safety or sanitary code standards.
   overcrowded: |
     A rental unit is considered overcrowded if there is not enough space for all of the tenants. Generally, having more than two people per bedroom can be considered overcrowding if the room is not large enough as defined in the MA State Sanitary Code (105 CMR 410.420(D)).
+  RAFT: |
+    RAFT is a state rental assistance program that tenants can use to help pay their rent every 12 months. Tenants in public or subsidized housing are limited to 6 months of their portion of the rent, but tenants without a subsidy can receive up to $7000 per year. Search for RAFT online or go to mass.gov and type in RAFT to learn more.
   retaliation: |
     Retaliation includes evicting you or raising your rent because you complained about housing problems. Retaliation is against the law. The court can protect you from retaliation.
   uninhabitable: |

--- a/docassemble/HousingCodeChecklist/data/questions/verified_complaint_and_motions_to_include.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/verified_complaint_and_motions_to_include.yml
@@ -59,6 +59,8 @@ code: |
     verified_complaint_tenant_voucher_at_risk
   complaint_ask_for_tro
   complaint_ask_for_relocation
+  complaint_raft_or_other_assistance
+  complaint_retaliation
   trial_court
   other_parties[0].phone_number
   users[0].email
@@ -238,6 +240,38 @@ fields:
       % endif
     field: complaint_ask_for_relocation
     datatype: yesnoradio    
+---
+id: rental assistance
+question: |
+  RAFT or rental assistance
+fields:
+  - label: |
+      % if person_answering == "tenant":
+      Have you applied for or previously used {RAFT} or other rental assistance to help pay for this apartment?
+      % else:
+      Has the tenant applied for or previously used {RAFT} or other rental assistance to help pay for this apartment?
+      % endif
+    field: complaint_raft_or_other_assistance
+    datatype: yesnoradio
+    label above field: True
+---
+id: complaint retaliation
+question: |
+  % if person_answering == "tenant":
+  Previous actions against your landlord
+  % else:
+  Previous actions against the tenant's landlord
+  % endif
+fields:
+  - label: |
+      % if person_answering == "tenant":
+      Have you been involved in tenant organizing, reported your landlord to your city or town, or taken legal action before now against your landlord?
+      % else:
+      Has the tenant been involved in tenant organizing, reported their landlord to their city or town, or taken legal action before now against their landlord?
+      % endif
+    field: complaint_retaliation
+    datatype: yesnoradio
+    label above field: True
 ---
 id: getting money
 question: |


### PR DESCRIPTION
<Type out your reasons for this PR>

Added two new questions to the complaint path so that interrogatories for RAFT/rental assistance and retaliation will be added when necessary.

<Add links to any solved issues here by using closing keywords>

fixes #604

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested a review

@nonprofittechy discovery is not fully implemented yet, but these questions need to be added to turn the related interrogatories on/off in the interview and in the actual discovery document. Open to any language changes!