### PR TITLE
Fix issue with simple condition no longer existing in spreadsheet

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -821,6 +821,8 @@ fields:
      % else:
      **Respond with the tenant's Answer to the eviction.** Use [MADE](https://gbls.org/MADE) to help the tenant build their Answer. Do not start a new court case with UpToCode.
      % endif
+    js show if: |
+      val("initial_screen_tenant_facing_eviction") == "pending" || val("initial_screen_tenant_facing_eviction") == "has case"
   - label: |
       % if person_answering == "tenant":
       Does your landlord already know about the problems in your home?
@@ -1092,6 +1094,7 @@ subquestion: |
   problem.
 
   ${ collapse_template(how_far_back_should_i_go_template) }
+
 fields:
   - label: |
       % if person_answering == "tenant":

--- a/docassemble/HousingCodeChecklist/data/questions/simple_conditions.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/simple_conditions.yml
@@ -9,7 +9,7 @@ data:
   - roach_insects
   - bedbug_insects
   - other_insects
-  - dampness_water
+  # - dampness_water # Removed
   - electric_general_maintenance
   - lead_paint_child
   - window_structural

--- a/docassemble/HousingCodeChecklist/load_data.py
+++ b/docassemble/HousingCodeChecklist/load_data.py
@@ -7,6 +7,7 @@ from docassemble.base.util import (
     DAObject,
     path_and_mimetype,
     today,
+    log,
 )
 import pandas as pd
 import os
@@ -77,14 +78,16 @@ class BaseDataLoader(DAObject):
     def load_rows(self, loci: List[Union[int, str]]) -> pd.DataFrame:
         """
         Retrieve a slice of the dataframe, using the provided loci (indexes) as the basis for
-        retrieval.
+        retrieval. Any locus not found in the index will be skipped (and logged).
         """
         df = self._load_data()
-        try:
-            rows = df.loc[loci]
-            return rows
-        except:
-            return pd.DataFrame()
+        existing = [l for l in loci if l in df.index]
+        missing  = [l for l in loci if l not in df.index]
+
+        for locus in missing:
+            log(f"Locus {locus!r} not found in data; skipping.")
+
+        return df.loc[existing]
 
     def get_rows(self, allowed_types: list = None, filter_column=None) -> pd.DataFrame:
         """


### PR DESCRIPTION
The list of "simple" conditions on the initial page was not showing because dampness_water was no longer in the spreadsheet.

1. Removed dampness_water from the list of simple conditions
2. Also made the load_rows(list) method more robust. now it will load all of the rows that exist and log missing ones instead of returning an empty dataframe

Going to merge, just highlighting for kelly to see for future knowledge
